### PR TITLE
replace absolute zeros with floating point zero

### DIFF
--- a/R/ODAC.R
+++ b/R/ODAC.R
@@ -51,7 +51,8 @@ ODAC.initialize <- function(ipdata,control,config){
                bhat_i = fit_i$coef,
                Vhat_i = summary(fit_i)$coef[,2]^2,   # not as glm, coxph summary can keep NA's! but vcov fills 0's!  
                site = config$site_id,
-               site_size = nrow(ipdata))
+               site_size = nrow(ipdata)
+  init$Vhat_i <- ifelse(init$Vhat_i == 0, 1e-22, init$Vhat_i))
   return(init)
 }
 


### PR DESCRIPTION
This fixes an issue in the meata analysis calculation of the ODACH when beta/var(beta) when var(beta)=0