### PR TITLE
5 add support for three columned surv object

### DIFF
--- a/R/ODACH_CC.R
+++ b/R/ODACH_CC.R
@@ -157,9 +157,12 @@ ODACH_CC.estimate <- function(ipdata, control, config) {
   # X <- as.matrix(ipdata[,-c(1:3)])
   # n <- length(time)
   # px <- ncol(X)
-  px <- ncol(ipdata) - 3
+  if ("tenter" %in% colnames(ipdata)) {
+    px <- ncol(ipdata) - 4
+  } else {
+    px <- ncol(ipdata) - 3
+  }
   # hasTies <- any(duplicated(ipdata$time))
-
   # download derivatives of other sites from the cloud
   # calculate 2nd order approx of the total logL
   logL_all_D1 <- rep(0, px)

--- a/R/ODACH_CC.R
+++ b/R/ODACH_CC.R
@@ -1,13 +1,13 @@
 # Copyright 2020 Penn Computing Inference Learning (PennCIL) lab
 #       https://penncil.med.upenn.edu/team/
 # This file is part of pda
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,9 +25,9 @@
 #                 step = 'initialize',
 #                 sites = sites,
 #                 heterogeneity = T,
-#                 model = 'ODACH_CC', 
-#                 method='Prentice', # 
-#                 full_cohort_size=NA, # 
+#                 model = 'ODACH_CC',
+#                 method='Prentice', #
+#                 full_cohort_size=NA, #
 #                 family = 'cox',
 #                 outcome = "status",
 #                 variables = c('age', 'sex'),
@@ -37,82 +37,120 @@
 
 #' @useDynLib pda
 #' @title ODACH_CC initialize
-#' 
+#'
 #' @usage ODACH_CC.initialize(ipdata, control, config)
 #' @param ipdata individual participant data
 #' @param control pda control data
 #' @param config local site configuration
-#' 
+#'
 #' @references  Chongliang Luo, et al. "ODACH: A One-shot Distributed Algorithm for Cox model with Heterogeneous Multi-center Data".
 #'               medRxiv, 2021, https://doi.org/10.1101/2021.04.18.21255694
 #' @return  list(bhat_i = fit_i$coef, Vhat_i = summary(fit_i)$coef[,2]^2, site=control$mysite, site_size= nrow(ipdata))
 #' @keywords internal
-ODACH_CC.initialize <- function(ipdata,control,config){
+ODACH_CC.initialize <- function(ipdata, control, config) {
   # coxph with case-cohort design
-  ipdata$ID = 1:nrow(ipdata) # for running cch... 
-  full_cohort_size = control$full_cohort_size[control$sites==config$site_id]
-  formula <- as.formula(paste("Surv(time, status) ~", paste(control$risk_factor, collapse = "+")))
-  fit_i <- survival::cch(formula, data = ipdata, subcoh = ~subcohort, id = ~ID, 
-                         cohort.size = full_cohort_size, method = control$method)
-  # fit_i$var # summary(fit_i)$coef[,2]^2
-  
-  init <- list(bhat_i = fit_i$coef,
-               Vhat_i = summary(fit_i)$coef[,"SE"]^2,   # not as glm, coxph summary can keep NA's! but vcov fills 0's!  
-               site = config$site_id,
-               site_size = nrow(ipdata),
-               full_cohort_size = full_cohort_size, 
-               method = control$method)
+  ipdata$ID <- 1:nrow(ipdata) # for running cch...
+  full_cohort_size <- control$full_cohort_size[control$sites == config$site_id]
+
+  risk_factors <- control$risk_factor
+  risk_factors <- risk_factors[!(risk_factors %in% c("subcohort"))]
+
+  argument_between_parenthesis <- stringr::str_match_all(control$outcome, "\\(([^\\)]+)\\)")[[1]][, 2]
+  surv_obj_elements <- stringr::str_trim(unlist(stringr::str_split(argument_between_parenthesis, ",")))
+  surv_obj_columns <- length(surv_obj_elements)
+
+  if (surv_obj_columns == 2) {
+    formula <- as.formula(paste("Surv(time, status) ~", paste(control$risk_factor, collapse = "+")))
+    fit_i <- survival::cch(formula,
+      data = ipdata, subcoh = ~subcohort, id = ~ID,
+      cohort.size = full_cohort_size, method = control$method
+    )
+    # fit_i$var # summary(fit_i)$coef[,2]^2
+
+    init <- list(
+      bhat_i = fit_i$coef,
+      Vhat_i = summary(fit_i)$coef[, "SE"]^2, # not as glm, coxph summary can keep NA's! but vcov fills 0's!
+      site = config$site_id,
+      site_size = nrow(ipdata),
+      full_cohort_size = full_cohort_size,
+      method = control$method
+    )
+  } else if (surv_obj_columns == 3) {
+    response <- "survival::Surv(tenter, texit, status) ~"
+    formula <- as.formula(paste(response, paste(risk_factors, collapse = "+"), " + cluster(ID)"))
+    dtime <- unique(ipdata$texit[ipdata$status == 1])
+    delta <- min(diff(sort(dtime))) / 2
+
+    ipdata_prentice <- ipdata
+    ipdata_prentice$tenter[ipdata_prentice$subcohort == 0] <- ipdata_prentice$texit[ipdata_prentice$subcohort == 0] - delta
+
+    fit_i <- survival::coxph(
+      formula,
+      data = ipdata_prentice
+    )
+
+    init <- list(
+      bhat_i = fit_i$coef,
+      Vhat_i = summary(fit_i)$coef[, "robust se"]^2,
+      site = config$site_id,
+      site_size = nrow(ipdata),
+      full_cohort_size = full_cohort_size,
+      method = control$method
+    )
+  }
   return(init)
 }
- 
+
 
 #' @useDynLib pda
 #' @title Generate pda derivatives
-#' 
+#'
 #' @usage ODACH_CC.derive(ipdata, control, config)
 #' @param ipdata individual participant data
 #' @param control pda control data
 #' @param config local site configuration
-#' 
-#' @details Calculate and broadcast 1st and 2nd order derivative at initial bbar 
 #'
-#' @import Rcpp  
+#' @details Calculate and broadcast 1st and 2nd order derivative at initial bbar
+#'
+#' @import Rcpp
 #' @return  list(bbar=bbar, site=control$mysite, site_size = nrow(ipdata), logL_D1=logL_D1, logL_D2=logL_D2)
 #' @keywords internal
-ODACH_CC.derive <- function(ipdata,control,config){
+ODACH_CC.derive <- function(ipdata, control, config) {
   # px <- ncol(ipdata) - 3
-  
-  bbar = control$beta_init
-  full_cohort_size = control$full_cohort_size[control$sites==config$site_id]
-  cc_prep = prepare_case_cohort(ipdata, control$method, full_cohort_size)
-  # grad_plk() 
+
+  bbar <- control$beta_init
+  full_cohort_size <- control$full_cohort_size[control$sites == config$site_id]
+  cc_prep <- prepare_case_cohort(ipdata, control$method, full_cohort_size)
+  # grad_plk()
   logL_D1 <- grad_plk(bbar, cc_prep)
   # hess_plk()
   logL_D2 <- hess_plk(bbar, cc_prep)
-  
-  derivatives <- list(bbar=bbar, 
-    site=config$site_id, site_size = nrow(ipdata), 
-    full_cohort_size=full_cohort_size,
-    logL_D1=logL_D1, logL_D2=logL_D2)
-  
+
+  derivatives <- list(
+    bbar = bbar,
+    site = config$site_id, site_size = nrow(ipdata),
+    full_cohort_size = full_cohort_size,
+    logL_D1 = logL_D1, logL_D2 = logL_D2
+  )
+
   return(derivatives)
 }
 
 
 #' @useDynLib pda
 #' @title PDA surrogate estimation
-#' 
+#'
 #' @usage ODACH_CC.estimate(ipdata, control, config)
 #' @param ipdata local data in data frame
 #' @param control pda control
 #' @param config cloud config
 #' @import data.table
-#' 
+#'
 #' @details step-4: construct and solve surrogate logL at the master/lead site
-#' @import Rcpp  
+#' @import Rcpp
 #' @return  list(btilde = sol$par, Htilde = sol$hessian, site=control$mysite, site_size=nrow(ipdata))
 #' @keywords internal
-ODACH_CC.estimate <- function(ipdata,control,config) {
+ODACH_CC.estimate <- function(ipdata, control, config) {
   # data sanity check ...
   # time <- ipdata$time
   # status <- ipdata$status
@@ -121,50 +159,54 @@ ODACH_CC.estimate <- function(ipdata,control,config) {
   # px <- ncol(X)
   px <- ncol(ipdata) - 3
   # hasTies <- any(duplicated(ipdata$time))
-  
+
   # download derivatives of other sites from the cloud
-  # calculate 2nd order approx of the total logL  
+  # calculate 2nd order approx of the total logL
   logL_all_D1 <- rep(0, px)
   logL_all_D2 <- matrix(0, px, px)
   N <- 0
-  for(site_i in control$sites){
-    derivatives_i <- pdaGet(paste0(site_i,'_derive'),config)
+  for (site_i in control$sites) {
+    derivatives_i <- pdaGet(paste0(site_i, "_derive"), config)
     logL_all_D1 <- logL_all_D1 + derivatives_i$logL_D1
     logL_all_D2 <- logL_all_D2 + matrix(unlist(derivatives_i$logL_D2), px, px)
     N <- N + derivatives_i$site_size
   }
-  
+
   # initial beta
   # bbar <- derivatives_i$b_meta
   bbar <- control$beta_init
-  full_cohort_size = control$full_cohort_size[control$sites==config$site_id]
-  cc_prep = prepare_case_cohort(ipdata, control$method, full_cohort_size) 
-  
+  full_cohort_size <- control$full_cohort_size[control$sites == config$site_id]
+  cc_prep <- prepare_case_cohort(ipdata, control$method, full_cohort_size)
+
   # logL at local site
   logL_local <- function(beta) log_plk(beta, cc_prep)
   logL_local_D1 <- function(beta) grad_plk(beta, cc_prep)
   logL_local_D2 <- function(beta) hess_plk(beta, cc_prep)
-  
+
   # surrogate log-L and its gradient
-  logL_diff_D1 <- logL_all_D1 - logL_local_D1(bbar)  # / N / n
-  logL_diff_D2 <- logL_all_D2 - logL_local_D2(bbar)  # / N / n
-  logL_tilde <- function(b) -(logL_local(b) + sum(b * logL_diff_D1) + 1/2 * t(b-bbar) %*% logL_diff_D2 %*% (b-bbar)) #  / n
+  logL_diff_D1 <- logL_all_D1 - logL_local_D1(bbar) # / N / n
+  logL_diff_D2 <- logL_all_D2 - logL_local_D2(bbar) # / N / n
+  logL_tilde <- function(b) -(logL_local(b) + sum(b * logL_diff_D1) + 1 / 2 * t(b - bbar) %*% logL_diff_D2 %*% (b - bbar)) #  / n
   # logL_tilde_D1 <- function(b) -(logL_local_D1(b) / n + logL_diff_D1 + logL_diff_D2 %*% (b-bbar))
   # cat(logL_diff_D1)
   # cat(logL_diff_D2)
   # cat(logL_tilde(bbar+0.2))
-  
-  # optimize the surrogate logL 
-  sol <- optim(par = bbar, 
-               fn = logL_tilde,
-               # gr = logL_tilde_D1,
-               hessian = TRUE,
-               method = control$optim_method,
-               control = list(maxit=control$optim_maxit))
-  
-  surr <- list(bbar=bbar, full_cohort_size=full_cohort_size, 
-               btilde = sol$par, Htilde = sol$hessian, site=config$site_id, site_size=nrow(ipdata))
-  
+
+  # optimize the surrogate logL
+  sol <- optim(
+    par = bbar,
+    fn = logL_tilde,
+    # gr = logL_tilde_D1,
+    hessian = TRUE,
+    method = control$optim_method,
+    control = list(maxit = control$optim_maxit)
+  )
+
+  surr <- list(
+    bbar = bbar, full_cohort_size = full_cohort_size,
+    btilde = sol$par, Htilde = sol$hessian, site = config$site_id, site_size = nrow(ipdata)
+  )
+
   return(surr)
 }
 
@@ -172,34 +214,35 @@ ODACH_CC.estimate <- function(ipdata,control,config) {
 
 #' @useDynLib pda
 #' @title PDA synthesize surrogate estimates from all sites, optional
-#' 
+#'
 #' @usage ODACH_CC.synthesize(ipdata, control, config)
 #' @param ipdata local data in data frame
 #' @param control pda control
 #' @param config cloud config
-#' 
+#'
 #' @details Optional step-4: synthesize all the surrogate est btilde_i from each site, if step-3 from all sites is broadcasted
-#' @import Rcpp  
+#' @import Rcpp
 #' @return  list(btilde=btilde,  Vtilde=Vtilde)
 #' @keywords internal
-ODACH_CC.synthesize <- function(ipdata,control,config) {
-  
+ODACH_CC.synthesize <- function(ipdata, control, config) {
   px <- length(control$risk_factor)
   K <- length(control$sites)
   btilde_wt_sum <- rep(0, px)
-  wt_sum <- rep(0, px)     # cov matrix?
-  
-  for(site_i in control$sites){
-    surr_i <- pdaGet(paste0(site_i,'_estimate'),config)
+  wt_sum <- rep(0, px) # cov matrix?
+
+  for (site_i in control$sites) {
+    surr_i <- pdaGet(paste0(site_i, "_estimate"), config)
     btilde_wt_sum <- btilde_wt_sum + surr_i$Htilde %*% surr_i$btilde
     wt_sum <- wt_sum + surr_i$Htilde
   }
-  
+
   # inv-Var weighted average est, and final Var = average Var-tilde
   btilde <- solve(wt_sum, btilde_wt_sum)
   Vtilde <- solve(wt_sum) * K
-  
+
   message("all surrogate estimates synthesized, no need to broadcast! ")
-  return(list(btilde=btilde, 
-              Vtilde=Vtilde))
+  return(list(
+    btilde = btilde,
+    Vtilde = Vtilde
+  ))
 }

--- a/R/case_cohort.R
+++ b/R/case_cohort.R
@@ -1,72 +1,98 @@
-
 ## prepare calculation for case-cohort design at ONE site
 # the purpose of this function is to "pre-calculate" the weight before calculating the log-likelihood
 # this would accelerate the subsequent calculation of log-likelihood
 # currently, we only provide Prentice weight; more options will be provided later
-prepare_case_cohort <- function(ipdata, method, full_cohort_size){
+prepare_case_cohort <- function(ipdata, method, full_cohort_size) {
   # for each site, pre-calculate the failure time points, the risk sets, and the respective weights
 
-  covariate <- as.matrix(ipdata[, -c(1:3)])
   # find over which position lies the failure times
   failure_position <- which(ipdata$status == 1)
   # find failure times
-  failure_times <- ipdata$time[which(ipdata$status == 1)]
+  failure_times <- ipdata$texit[which(ipdata$status == 1)]
   # the number of failures
   failure_num <- length(failure_times)
-  # full_cohort_size = nrow(ipdata) # ?
-  Barlow_IPW <- full_cohort_size / sum(ipdata$subcohort)
- 
+
   risk_size <- 0
-  risk_sets <- as.list(rep(NA, failure_num ))
-  risk_set_weights <- as.list(rep(NA, failure_num ))
-  for(j in 1:failure_num){
-    my_risk_set1 <- which((ipdata$subcohort == 1) & (ipdata$time >= failure_times[j]))
-    risk_size <- risk_size + length(my_risk_set1)
-    if(method == "Prentice"){
+  risk_sets <- as.list(rep(NA, failure_num))
+  risk_set_weights <- as.list(rep(NA, failure_num))
+  if ("tenter" %in% colnames(ipdata)) {
+    covariate <- as.matrix(ipdata[, -c(1:4)])
+
+    for (j in 1:failure_num) {
+      # Prentice weight: Subjects in the risk set (R_j) inside subcohort get a weight of 1
+      # R_i = {j: Y_J >= Y_i > a_j};  Y_i = min(T_i, W_i); T_i: failure time; W_i: censoring time; a_i: subject enters the study
+      in_subcohort_and_failtime_after_event <- which((ipdata$subcohort == 1) & (ipdata$texit >= failure_times[j]))
+      in_subcohort_and_entry_before_event <- which((ipdata$subcohort == 1) & (ipdata$tenter < failure_times[j]))
+      my_risk_set1 <- intersect(in_subcohort_and_failtime_after_event, in_subcohort_and_entry_before_event)
       my_weight1 <- rep(1, length(my_risk_set1))
+
+      # Prentice weight: Subjects in the risk set (R_j) outside subcohort get a weight of 1 but only for subjects that fail at the time of event
+      # R_i = {j: Y_J >= Y_i > a_j};  Y_i = min(T_i, W_i); T_i: failure time; W_i: censoring time; a_i: subject enters the study
+      out_subcohort_and_failtime_at_event <- which((ipdata$subcohort == 0) & (ipdata$texit == failure_times[j]))
+      out_subcohort_and_entry_before_event <- which((ipdata$subcohort == 0) & (ipdata$tenter < failure_times[j]))
+      my_risk_set2 <- intersect(out_subcohort_and_failtime_at_event, out_subcohort_and_entry_before_event)
+      my_weight2 <- rep(1, length(my_risk_set2))
+
+      risk_sets[[j]] <- c(my_risk_set1, my_risk_set2)
+      risk_set_weights[[j]] <- c(my_weight1, my_weight2)
     }
-    if(method == "Barlow"){
-      my_weight1 <- rep(Barlow_IPW, length(my_risk_set1))
-    }
-    if(ipdata$subcohort[which(ipdata$time == failure_times[j])] == 0){
-      my_risk_set2 <- which(ipdata$time == failure_times[j])
-      my_weight2 <- 1
-    }else{
-      my_risk_set2 <- c()
-      my_weight2 <- c()
-      if(method == "Barlow"){
-        my_weight1[which(ipdata$time[my_risk_set1] == failure_times[j])] <- 1 
+  } else {
+    covariate <- as.matrix(ipdata[, -c(1:3)])
+
+    # full_cohort_size = nrow(ipdata) # ?
+    Barlow_IPW <- full_cohort_size / sum(ipdata$subcohort)
+
+
+    for (j in 1:failure_num) {
+      my_risk_set1 <- which((ipdata$subcohort == 1) & (ipdata$time >= failure_times[j]))
+      risk_size <- risk_size + length(my_risk_set1)
+      if (method == "Prentice") {
+        my_weight1 <- rep(1, length(my_risk_set1))
       }
+      if (method == "Barlow") {
+        my_weight1 <- rep(Barlow_IPW, length(my_risk_set1))
+      }
+      if (ipdata$subcohort[which(ipdata$time == failure_times[j])] == 0) {
+        my_risk_set2 <- which(ipdata$time == failure_times[j])
+        my_weight2 <- 1
+      } else {
+        my_risk_set2 <- c()
+        my_weight2 <- c()
+        if (method == "Barlow") {
+          my_weight1[which(ipdata$time[my_risk_set1] == failure_times[j])] <- 1
+        }
+      }
+      risk_sets[[j]] <- c(my_risk_set1, my_risk_set2)
+      risk_set_weights[[j]] <- c(my_weight1, my_weight2)
     }
-    risk_sets[[j]] <- c(my_risk_set1, my_risk_set2)
-    risk_set_weights[[j]] <- c(my_weight1, my_weight2)
-  } 
-  
-  return(list(# ipdata = ipdata,
-              full_cohort_size = full_cohort_size,
-              covariate = covariate,
-              failure_position = failure_position,
-              failure_num = failure_num,
-              risk_sets = risk_sets,
-              risk_set_weights = risk_set_weights ))
+  }
+
+  return(list( # ipdata = ipdata,
+    full_cohort_size = full_cohort_size,
+    covariate = covariate,
+    failure_position = failure_position,
+    failure_num = failure_num,
+    risk_sets = risk_sets,
+    risk_set_weights = risk_set_weights
+  ))
 }
 
 # this function calculate the log pseudo-likelihood for ONE site
 # cc_prep is the output of prepare_case_cohort()
-log_plk <- function(beta, cc_prep){
-  X = cc_prep$covariate # ipdata[,-c(1:2)]
-  failure_position = cc_prep$failure_position 
-  failure_num = cc_prep$failure_num 
-  risk_sets = cc_prep$risk_sets 
-  risk_set_weights = cc_prep$risk_set_weights
-  
-  numerator_terms <- c(X[failure_position, ] %*% beta) 
+log_plk <- function(beta, cc_prep) {
+  X <- cc_prep$covariate # ipdata[,-c(1:2)]
+  failure_position <- cc_prep$failure_position
+  failure_num <- cc_prep$failure_num
+  risk_sets <- cc_prep$risk_sets
+  risk_set_weights <- cc_prep$risk_set_weights
+
+  numerator_terms <- c(X[failure_position, ] %*% beta)
   res <- sum(numerator_terms)
-  for(j in 1:failure_num){
-    temp_term <- sum(c(exp(X[risk_sets[[j]], ] %*% beta )) * risk_set_weights[[j]])
-    if(temp_term > 0){
+  for (j in 1:failure_num) {
+    temp_term <- sum(c(exp(X[risk_sets[[j]], ] %*% beta)) * risk_set_weights[[j]])
+    if (temp_term > 0) {
       res <- res - log(temp_term)
-    }else{
+    } else {
       res <- res - numerator_terms[j]
     }
   }
@@ -77,19 +103,19 @@ log_plk <- function(beta, cc_prep){
 
 # this function calculate the gradient of log pseudo-likelihood for ONE site
 # cc_prep is the output of prepare_case_cohort()
-grad_plk <- function(beta, cc_prep){
-  X = cc_prep$covariate # ipdata[,-c(1:2)]
-  failure_position = cc_prep$failure_position 
-  failure_num = cc_prep$failure_num 
-  risk_sets = cc_prep$risk_sets 
-  risk_set_weights = cc_prep$risk_set_weights
-  
-  res = colSums(X[failure_position,])
-  for(j in 1:failure_num){
-    if(length(risk_sets[[j]]) > 1){
-      temp_scalar <- c(exp(X[risk_sets[[j]], ] %*% beta )) * risk_set_weights[[j]]
-      res <- res - apply(sweep(X[risk_sets[[j]], ], 1, temp_scalar, "*"), 2, sum) / sum(temp_scalar) 
-    }else{
+grad_plk <- function(beta, cc_prep) {
+  X <- cc_prep$covariate # ipdata[,-c(1:2)]
+  failure_position <- cc_prep$failure_position
+  failure_num <- cc_prep$failure_num
+  risk_sets <- cc_prep$risk_sets
+  risk_set_weights <- cc_prep$risk_set_weights
+
+  res <- colSums(X[failure_position, ])
+  for (j in 1:failure_num) {
+    if (length(risk_sets[[j]]) > 1) {
+      temp_scalar <- c(exp(X[risk_sets[[j]], ] %*% beta)) * risk_set_weights[[j]]
+      res <- res - apply(sweep(X[risk_sets[[j]], ], 1, temp_scalar, "*"), 2, sum) / sum(temp_scalar)
+    } else {
       res <- res - X[risk_sets[[j]], ] * risk_set_weights[[j]]
     }
   }
@@ -99,33 +125,33 @@ grad_plk <- function(beta, cc_prep){
 
 # this function calculate the Hessian of log pseudo-likelihood for ONE site
 # cc_prep is the output of prepare_case_cohort
-hess_plk <- function(beta, cc_prep){
-  X = cc_prep$covariate # ipdata[,-c(1:2)]
-  failure_position = cc_prep$failure_position 
-  failure_num = cc_prep$failure_num 
-  risk_sets = cc_prep$risk_sets 
-  risk_set_weights = cc_prep$risk_set_weights
-  
+hess_plk <- function(beta, cc_prep) {
+  X <- cc_prep$covariate # ipdata[,-c(1:2)]
+  failure_position <- cc_prep$failure_position
+  failure_num <- cc_prep$failure_num
+  risk_sets <- cc_prep$risk_sets
+  risk_set_weights <- cc_prep$risk_set_weights
+
   d <- length(beta)
-  if(length(risk_sets[[1]]) > 1){
-    temp_scalar <- c(exp(X[risk_sets[[1]], ] %*% beta )) * risk_set_weights[[1]]
+  if (length(risk_sets[[1]]) > 1) {
+    temp_scalar <- c(exp(X[risk_sets[[1]], ] %*% beta)) * risk_set_weights[[1]]
     temp_vec <- apply(sweep(X[risk_sets[[1]], ], 1, temp_scalar, "*"), 2, sum)
     temp_mat <- sweep(X[risk_sets[[1]], ], 1, sqrt(temp_scalar), "*")
-    res <- temp_vec %*% t(temp_vec)  / (sum(temp_scalar))^2  - crossprod(temp_mat) / sum(temp_scalar)
-  }else{
+    res <- temp_vec %*% t(temp_vec) / (sum(temp_scalar))^2 - crossprod(temp_mat) / sum(temp_scalar)
+  } else {
     res <- matrix(0, d, d)
   }
-  if(failure_num > 1){
-    for(j in 2:failure_num){
-      if(length(risk_sets[[j]]) > 1){
-        temp_scalar <- c(exp(X[risk_sets[[j]], ] %*% beta )) * risk_set_weights[[j]]
+  if (failure_num > 1) {
+    for (j in 2:failure_num) {
+      if (length(risk_sets[[j]]) > 1) {
+        temp_scalar <- c(exp(X[risk_sets[[j]], ] %*% beta)) * risk_set_weights[[j]]
         temp_vec <- apply(sweep(X[risk_sets[[j]], ], 1, temp_scalar, "*"), 2, sum)
         temp_mat <- sweep(X[risk_sets[[j]], ], 1, sqrt(temp_scalar), "*")
-        res <- res - crossprod(temp_mat) / sum(temp_scalar) + temp_vec %*% t(temp_vec)  / (sum(temp_scalar))^2
+        res <- res - crossprod(temp_mat) / sum(temp_scalar) + temp_vec %*% t(temp_vec) / (sum(temp_scalar))^2
       }
     }
   }
-  
+
   return(res)
 }
 
@@ -133,28 +159,34 @@ hess_plk <- function(beta, cc_prep){
 
 # this function fits Cox PH to case-cohort (survival::cch) with the pooled multi-site data
 #' @export
-cch_pooled <- function(formula, data, subcoh='subcohort', site='site',
-                       full_cohort_size, method = "Prentice", optim_method = "BFGS"
-                       ){ 
-  n = nrow(data)  
-  site_uniq = unique(data[,site]) 
+cch_pooled <- function(formula, data, subcoh = "subcohort", site = "site",
+                       full_cohort_size, method = "Prentice", optim_method = "BFGS") {
+  n <- nrow(data)
+  site_uniq <- unique(data[, site])
   # formula <- as.formula(paste(control$outcome, paste(variables, collapse = "+"), sep = '~'))
   mf <- model.frame(formula, data)
-  
-  ipdata = data.table::data.table(site=data[,site],
-                                  time=as.numeric(model.response(mf))[1:n], 
-                                  status=as.numeric(model.response(mf))[-c(1:n)],
-                                  subcohort = data[,subcoh], 
-                                  model.matrix(formula, mf)[,-1]) 
-  
-  initial_beta = rep(0, ncol(ipdata)-4)
-  names(initial_beta) = names(ipdata)[-c(1:4)]
-  pool_fun <- function(beta) sum(sapply(site_uniq, function(site_id) 
-        log_plk(beta, prepare_case_cohort(ipdata[site==site_id,-'site'], method, full_cohort_size[site_id]))))
+
+  ipdata <- data.table::data.table(
+    site = data[, site],
+    time = as.numeric(model.response(mf))[1:n],
+    status = as.numeric(model.response(mf))[-c(1:n)],
+    subcohort = data[, subcoh],
+    model.matrix(formula, mf)[, -1]
+  )
+
+  initial_beta <- rep(0, ncol(ipdata) - 4)
+  names(initial_beta) <- names(ipdata)[-c(1:4)]
+  pool_fun <- function(beta) {
+    sum(sapply(site_uniq, function(site_id) {
+      log_plk(beta, prepare_case_cohort(ipdata[site == site_id, -"site"], method, full_cohort_size[site_id]))
+    }))
+  }
   # pool_fun(initial_beta)
-  
-  result <- optim(par = initial_beta, fn = pool_fun, 
-                  control = list(fnscale = -1), method = optim_method ) 
-   
+
+  result <- optim(
+    par = initial_beta, fn = pool_fun,
+    control = list(fnscale = -1), method = optim_method
+  )
+
   return(result)
 }

--- a/R/pda.R
+++ b/R/pda.R
@@ -520,11 +520,21 @@ pda <- function(ipdata=NULL,site_id,control=NULL,dir=NULL,uri=NULL,secret=NULL,
     }
   } else if(control$model=='ODACH_CC'){
     if (!is.null(ipdata)){
-      ipdata = data.table::data.table(time=as.numeric(model.response(mf))[1:n], 
-                                      status=as.numeric(model.response(mf))[-c(1:n)],
-                                      subcohort = ipdata$subcohort,
-                                      # sampling_weight = ipdata$sampling_weight,
-                                      model.matrix(formula, mf)[,-1])
+      Y <- model.extract(mf, "response")
+      if (ncol(Y) == 3) {
+          ipdata <- data.table::data.table(tenter=as.numeric(Y[1:n, 1]), 
+                                           texit=as.numeric(Y[1:n, 2]), 
+                                           status=as.numeric(Y[1:n, 3]),
+                                           subcohort = ipdata$subcohort,
+                                           # sampling_weight = ipdata$sampling_weight,
+                                           model.matrix(formula, mf)[,-1])
+      } else {
+          ipdata <- data.table::data.table(time=as.numeric(model.response(mf))[1:n], 
+                                           status=as.numeric(model.response(mf))[-c(1:n)],
+                                           subcohort = ipdata$subcohort,
+                                           # sampling_weight = ipdata$sampling_weight,
+                                           model.matrix(formula, mf)[,-1])
+      }
       # convert irregular risk factor names, e.g. `Group (A,B,C) B` to Group..A.B.C..B
       # this should (and will) apply to all other models...
       ipdata = data.table(data.frame(ipdata)) 


### PR DESCRIPTION
Hi,

Merge request consists of 2 main updates:
1- add support for a survival object input with three columns: survival::Surv( time_entry, time_exit, status ). The added features affect only the ODACH_CC pipeline.

2- add a pipeline to calculate risk sets and Prentice weights for a three columned style survival object when calculating hazard ratios.