### PR TITLE
6 odach cc strata reproducibility fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pda
 Type: Package
 Title: Privacy-Preserving Distributed Algorithms
-Version: 1.3.1
+Version: 1.3.2
 Date: 2025-12-06
 Authors@R: c(person("Chongliang", "Luo", role=c("cre"), email ="luocl3009@gmail.com"),
                 person("Rui", "Duan", role="aut"), person("Mackenzie", "Edmondson", role="aut"),

--- a/R/ODACH_CC.R
+++ b/R/ODACH_CC.R
@@ -87,12 +87,63 @@ ODACH_CC.initialize <- function(ipdata,control,config){
  
 
 
+#' Compute First Derivative of the Log-Likelihood for a Cox Model
+#'
+#' This function extracts the score residuals from a fitted Cox proportional
+#' hazards model (`coxph` object) and computes the first derivative of the
+#' log-likelihood by summing these score residuals over all observations.
+#'
+#' @param coxph_fit A fitted Cox proportional hazards model object returned by
+#'   `survival::coxph()`.
+#'
+#' @return A numeric vector containing the first derivative of the log-likelihood
+#'   (score function) evaluated at the fitted model parameters.
+#'
+#' @details
+#' The score residuals correspond to the gradient of the log-likelihood with
+#' respect to each model parameter. Summing them provides the overall gradient
+#' vector, which is useful for diagnostics, optimization checks, or integration
+#' into custom estimation procedures.
+#'
+#' @examples
+#' \dontrun{
+#'   library(survival)
+#'   fit <- coxph(Surv(time, status) ~ age + sex, data = lung)
+#'   get_logL_D1(fit)
+#' }
 get_logL_D1 <- function(coxph_fit){
   grad <- colSums(stats::residuals(coxph_fit, type = "score"))
   logL_D1 <- as.vector(grad)
   return(logL_D1)
 }
 
+
+#' Compute Second Derivative (Hessian) of the Log-Likelihood for a Cox Model
+#'
+#' This function computes the observed information matrix (negative Hessian of 
+#' the log-likelihood) for a fitted Cox proportional hazards model. It extracts 
+#' per-event information matrices from `survival::coxph.detail()` and sums them 
+#' to obtain the full observed information matrix evaluated at the fitted model 
+#' parameters.
+#'
+#' @param coxph_fit A fitted Cox proportional hazards model object created by 
+#'   `survival::coxph()`.
+#'
+#' @return A numeric matrix representing the second derivative (Hessian) of the 
+#'   log-likelihood function. The matrix is returned without dimnames.
+#'
+#' @details
+#' The observed information matrix is computed as the negative sum of the 
+#' per-timepoint information matrices produced by `coxph.detail()`. This matrix 
+#' is useful for variance estimation, asymptotic inference, numerical 
+#' optimization procedures, and second‑order approximations of the likelihood.
+#'
+#' @examples
+#' \dontrun{
+#'   library(survival)
+#'   fit <- coxph(Surv(time, status) ~ age + sex, data = lung)
+#'   get_logL_D2(fit)
+#' }
 get_logL_D2 <- function(coxph_fit){
   det <- survival::coxph.detail(coxph_fit, riskmat = FALSE)
   I_total <- apply(det$imat, c(1, 2), sum)

--- a/R/ODACH_CC.R
+++ b/R/ODACH_CC.R
@@ -153,7 +153,9 @@ ODACH_CC.derive <- function(ipdata,control,config){
   # precision <- min(diff(times)) / 2
   # ipdata[ipdata$subcohort == 0, "time_in"] <- ipdata[ipdata$subcohort == 0, "time_out"] - precision
   ipdata$ID = 1:nrow(ipdata) # for running coxph/cch...  
-  formula_i <- as.formula(paste("Surv(time_in, time_out, status) ~", paste(control$risk_factor, collapse = "+"), '+ cluster(ID)')) 
+  formula_i <- as.formula(
+    paste("Surv(time_in, time_out, status) ~", 
+    paste(control$risk_factor, collapse = "+"), '+ strata(strata_id) + cluster(ID)')) 
   fit_i <- survival::coxph(
     formula_i, 
     data=ipdata, 
@@ -289,7 +291,9 @@ ODACH_CC.estimate <- function(ipdata,control,config) {
   # precision <- min(diff(times)) / 2
   # ipdata[ipdata$subcohort == 0, "time_in"] <- ipdata[ipdata$subcohort == 0, "time_out"] - precision
   ipdata$ID = 1:nrow(ipdata) # for running coxph/cch...  
-  formula_i <- as.formula(paste("Surv(time_in, time_out, status) ~", paste(control$risk_factor, collapse = "+"), '+ cluster(ID)')) 
+  formula_i <- as.formula(
+    paste("Surv(time_in, time_out, status) ~", 
+    paste(control$risk_factor, collapse = "+"), '+ strata(strata_id) + cluster(ID)')) 
   fit_i <- survival::coxph(
     formula_i, 
     data=ipdata, 

--- a/R/ODACH_CC.R
+++ b/R/ODACH_CC.R
@@ -44,9 +44,9 @@ ODACH_CC.initialize <- function(ipdata,control,config){
   ipdata_i = ipdata[,-(which(col_deg)+5),with=F]
   ipdata_i$ID = 1:nrow(ipdata_i) # for running coxph/cch... 
   
-  times <- sort(unique(c(ipdata$time_in, ipdata$time_out)))
-  precision <- min(diff(times)) / 2
-  ipdata_i[ipdata_i$subcohort == 0, "time_in"] <- ipdata_i[ipdata_i$subcohort == 0, "time_out"] - precision
+  # times <- sort(unique(c(ipdata$time_in, ipdata$time_out)))
+  # precision <- min(diff(times)) / 2
+  # ipdata_i[ipdata_i$subcohort == 0, "time_in"] <- ipdata_i[ipdata_i$subcohort == 0, "time_out"] - precision
 
 
   ## 3 ways to do local est: cch, coxph with a tweak of the formula, and cch_pooled
@@ -149,9 +149,9 @@ ODACH_CC.derive <- function(ipdata,control,config){
   # formula_i <- as.formula(paste("Surv(time_in, time_out, status) ~", paste(control$risk_factor[!col_deg], collapse = "+"), '+ cluster(ID)')) 
   # fit_i <- tryCatch(survival::coxph(formula_i, data=ipdata_i, robust=T, init=bbar[!col_deg], iter=0), error=function(e) NULL) # 20250326: init/iter trick
 
-  times <- sort(unique(c(ipdata$time_in, ipdata$time_out)))
-  precision <- min(diff(times)) / 2
-  ipdata[ipdata$subcohort == 0, "time_in"] <- ipdata[ipdata$subcohort == 0, "time_out"] - precision
+  # times <- sort(unique(c(ipdata$time_in, ipdata$time_out)))
+  # precision <- min(diff(times)) / 2
+  # ipdata[ipdata$subcohort == 0, "time_in"] <- ipdata[ipdata$subcohort == 0, "time_out"] - precision
   ipdata$ID = 1:nrow(ipdata) # for running coxph/cch...  
   formula_i <- as.formula(paste("Surv(time_in, time_out, status) ~", paste(control$risk_factor, collapse = "+"), '+ cluster(ID)')) 
   fit_i <- survival::coxph(
@@ -285,9 +285,9 @@ ODACH_CC.estimate <- function(ipdata,control,config) {
   logL_tilde <- function(b) -(logL_local(b) + sum(b * logL_diff_D1) + 1/2 * t(b-bbar) %*% logL_diff_D2 %*% (b-bbar)) #  / n
   # logL_tilde_D1 <- function(b) -(logL_local_D1(b) / n + logL_diff_D1 + logL_diff_D2 %*% (b-bbar)) 
   
-  times <- sort(unique(c(ipdata$time_in, ipdata$time_out)))
-  precision <- min(diff(times)) / 2
-  ipdata[ipdata$subcohort == 0, "time_in"] <- ipdata[ipdata$subcohort == 0, "time_out"] - precision
+  # times <- sort(unique(c(ipdata$time_in, ipdata$time_out)))
+  # precision <- min(diff(times)) / 2
+  # ipdata[ipdata$subcohort == 0, "time_in"] <- ipdata[ipdata$subcohort == 0, "time_out"] - precision
   ipdata$ID = 1:nrow(ipdata) # for running coxph/cch...  
   formula_i <- as.formula(paste("Surv(time_in, time_out, status) ~", paste(control$risk_factor, collapse = "+"), '+ cluster(ID)')) 
   fit_i <- survival::coxph(

--- a/R/ODACH_CC.R
+++ b/R/ODACH_CC.R
@@ -44,10 +44,6 @@ ODACH_CC.initialize <- function(ipdata,control,config){
   ipdata_i = ipdata[,-(which(col_deg)+5),with=F]
   ipdata_i$ID = 1:nrow(ipdata_i) # for running coxph/cch... 
   
-  # times <- sort(unique(c(ipdata$time_in, ipdata$time_out)))
-  # precision <- min(diff(times)) / 2
-  # ipdata_i[ipdata_i$subcohort == 0, "time_in"] <- ipdata_i[ipdata_i$subcohort == 0, "time_out"] - precision
-
 
   ## 3 ways to do local est: cch, coxph with a tweak of the formula, and cch_pooled
   # to avoid numerical error using cch() indicated by Ali, we use coxph with a tweak of the formula...
@@ -173,7 +169,6 @@ ODACH_CC.derive <- function(ipdata,control,config){
   bbar = control$beta_init
   
   # cc_prep = prepare_case_cohort(ipdata)
-  # full_cohort_size = control$full_cohort_size[control$sites==config$site_id]
 
 
   # logL_D1 <- rep(0, px) # is it 0？
@@ -188,21 +183,8 @@ ODACH_CC.derive <- function(ipdata,control,config){
   #                             failure_num = cc_prep$failure_num,
   #                             risk_sets = cc_prep$risk_sets)
   
-  # handle data degeneration (e.g. missing categories in some site). This could be in pda()?
-  # col_deg = apply(ipdata[,-c(1:5)],2,var)==0    # degenerated X columns...
-  # ipdata_i = ipdata[,-(which(col_deg)+5),with=F]
-  # ipdata_i$ID = 1:nrow(ipdata_i) # for running coxph/cch...  
   
-  # times <- sort(unique(c(ipdata$time_in, ipdata$time_out)))
-  # precision <- min(diff(times)) / 2
-  # ipdata_i[ipdata_i$subcohort == 0, "time_in"] <- ipdata_i[ipdata_i$subcohort == 0, "time_out"] - precision
   ## get intermediate (sandwich meat) for robust variance est of ODACH_CC  
-  # formula_i <- as.formula(paste("Surv(time_in, time_out, status) ~", paste(control$risk_factor[!col_deg], collapse = "+"), '+ cluster(ID)')) 
-  # fit_i <- tryCatch(survival::coxph(formula_i, data=ipdata_i, robust=T, init=bbar[!col_deg], iter=0), error=function(e) NULL) # 20250326: init/iter trick
-
-  # times <- sort(unique(c(ipdata$time_in, ipdata$time_out)))
-  # precision <- min(diff(times)) / 2
-  # ipdata[ipdata$subcohort == 0, "time_in"] <- ipdata[ipdata$subcohort == 0, "time_out"] - precision
   ipdata$ID = 1:nrow(ipdata) # for running coxph/cch...  
   formula_i <- as.formula(
     paste("Surv(time_in, time_out, status) ~", 
@@ -214,57 +196,15 @@ ODACH_CC.derive <- function(ipdata,control,config){
     method = "breslow",
     control = survival::coxph.control(iter.max = 0)
     )
-  # y <- survival::Surv(ipdata$time_in, ipdata$time_out, ipdata$status)
-  # X <- cc_prep$X
-  # fit_i__ <- survival::coxph.fit(
-  #   x = X,
-  #   y = y, 
-  #   strata=ipdata$strata,  
-  #   init=bbar, 
-  #   method = "breslow",
-  #   rownames = as.character(seq_len(nrow(X))),
-  #   control = survival::coxph.control(iter.max = 0),)
-  # print(fit_i__$var)
-  # print(logL_D1)
-
-  # grad <- colSums(stats::residuals(fit_i, type = "score"))
-  # logL_D1 <- as.vector(grad)
-  logL_D1 <- get_logL_D1(fit_i)
   
-  # print(as.vector(grad))
-  # print(sum(abs(as.vector(grad)- logL_D1)))
-  # print(as.vector(coef(fit_i)))
-  # print(as.vector(coef(fit_i__)[!col_deg]))
-
-
+  logL_D1 <- get_logL_D1(fit_i)
+  logL_D2 <- get_logL_D2(fit_i)
+  
   score_resid <- resid(fit_i, type = "score")  # n x p matrix  
   S_i <- matrix(0, px, px)   # this is the meat in sandwich var
   # S_i[!col_deg, !col_deg] <- crossprod(score_resid)
   S_i <- crossprod(score_resid)
-  # print(S_i)
-  # print(as.vector(crossprod(resid(fit_i, type = "score"))))
-  # print(sum(abs(S_i- as.vector(crossprod(resid(fit_i__, type = "score"))))))
-  # print(logL_D2)
-  # print(-as.matrix(fit_i__$imat))
-  # print(str(fit_i__))
   
-
-  # det <- survival::coxph.detail(fit_i, riskmat = FALSE)
-  # # print(dim(det$imat))
-  # I_total <- apply(det$imat, c(1, 2), sum)
-  # logL_D2 <- -as.matrix(I_total)
-  # dimnames(logL_D2) <- NULL
-  logL_D2 <- get_logL_D2(fit_i)
-  
-  # print(sum(abs(Hessian - logL_D2)))
-  # I_surv <- Reduce(`+`, det$imat)
-  # H_surv <- -I_surv
-  # print(H_surv)
-
-  # print(logL_D2[1])
-  # print(as.matrix(solve(fit_i__$var))[1])
-  # print(sum(abs(logL_D2[!col_deg, !col_deg]+as.matrix(solve(fit_i__$var[!col_deg, !col_deg])))))
-  # stop("MES")
   # S_i[!col_deg, !col_deg] <- logL_D2[!col_deg, !col_deg] %*% fit_i$var %*% logL_D2[!col_deg, !col_deg] # Skhat in Yudong's note...
   
   derivatives <- list(bbar=bbar, 
@@ -338,9 +278,6 @@ ODACH_CC.estimate <- function(ipdata,control,config) {
   logL_tilde <- function(b) -(logL_local(b) + sum(b * logL_diff_D1) + 1/2 * t(b-bbar) %*% logL_diff_D2 %*% (b-bbar)) #  / n
   # logL_tilde_D1 <- function(b) -(logL_local_D1(b) / n + logL_diff_D1 + logL_diff_D2 %*% (b-bbar)) 
   
-  # times <- sort(unique(c(ipdata$time_in, ipdata$time_out)))
-  # precision <- min(diff(times)) / 2
-  # ipdata[ipdata$subcohort == 0, "time_in"] <- ipdata[ipdata$subcohort == 0, "time_out"] - precision
   ipdata$ID = 1:nrow(ipdata) # for running coxph/cch...  
   formula_i <- as.formula(
     paste("Surv(time_in, time_out, status) ~", 
@@ -360,45 +297,6 @@ ODACH_CC.estimate <- function(ipdata,control,config) {
   logL_local_D2_bbar <- get_logL_D2(fit_i)
   logL_diff_D2 <- logL_all_D2 - logL_local_D2_bbar
   
-  # col_deg = apply(ipdata[,-c(1:5)],2,var)==0    # degenerated X columns...
-  # ipdata_i = ipdata[,-(which(col_deg)+5),with=F]
-  # ipdata_i$ID = 1:nrow(ipdata_i) # for running coxph/cch... 
-  # formula <- as.formula(paste("Surv(time_in, time_out, status) ~", 
-  #                               paste(control$risk_factor[!col_deg], collapse = "+"), 
-  #                               "+ strata(strata_id) + cluster(ID)"))
-  # print(formula)
-  
-  # logL_tilde__ <- function(b){
-  #   fit <- survival::coxph(
-  #   formula_i, 
-  #   data=ipdata, 
-  #   init=b, 
-  #   method = "breslow",
-  #   control = survival::coxph.control(iter.max = 1)
-  #   )
-  #   res <-  -(fit$loglik[2] + sum(b * logL_diff_D1__) + 1/2 * t(b-bbar) %*% logL_diff_D2__ %*% (b-bbar))
-  #   return(res)
-  # }
-#   logL_tilde__ <- function(b) {
-#   fit <- try(
-#     survival::coxph(
-#       formula_i,
-#       data = ipdata,
-#       init = b,
-#       method = "breslow",
-#       control = survival::coxph.control(iter.max = 0)
-#     ),
-#     silent = TRUE
-#   )
-#   if (inherits(fit, "try-error")) {
-#     return(1e100)
-#   }
-#   res <-  -(fit$loglik[2] + sum(b * logL_diff_D1__) + 1/2 * t(b-bbar) %*% logL_diff_D2__ %*% (b-bbar))
-#   return(res)
-# } 
-  
-
-
   # optimize the surrogate logL 
   sol <- optim(par = bbar, 
                fn = logL_tilde,

--- a/R/case_cohort.R
+++ b/R/case_cohort.R
@@ -27,8 +27,9 @@ prepare_case_cohort <- function(ipdata_i){
     fpos_j <- failure_position[j]
     t_j    <- failure_times[j] 
     idx_strata <- strata_id == strata_id[fpos_j]
-    idx_time   <- (ipdata_i$time_in <= t_j) & (ipdata_i$time_out >= t_j) 
-    temp_risk[[j]] <- which(idx_strata & idx_time)
+    idx_time   <- (ipdata_i$subcohort == 1) & (ipdata_i$time_in <= t_j) & (ipdata_i$time_out >= t_j) 
+    idx_time_f_out   <- (ipdata_i$subcohort == 0) & (ipdata_i$time_out == t_j)
+    temp_risk[[j]] <- c(which(idx_strata & idx_time),which(idx_strata & idx_time_f_out))
   } 
 
   return(list(X = X,

--- a/R/pda.R
+++ b/R/pda.R
@@ -39,12 +39,12 @@ pdaPut <- function(obj,name,config,upload_without_confirm=F,silent_message=F,dig
   obj_Json <- jsonlite::toJSON(obj, digits = digits)  # RJSONIO::toJSON(tt) keep vec name?
   file_name <- paste0(name, '.json')  
   
-  if(!is.null(config$uri)){
-    mymessage(paste("Put",file_name,"on public cloud:"))
-  }else{
-    mymessage(paste("Put",file_name,"on local directory", config$dir, ':'))
-  }
-  mymessage(obj_Json)
+  # if(!is.null(config$uri)){
+  #   mymessage(paste("Put",file_name,"on public cloud:"))
+  # }else{
+  #   mymessage(paste("Put",file_name,"on local directory", config$dir, ':'))
+  # }
+  # mymessage(obj_Json)
   
   # if(interactive()) {
   if(upload_without_confirm==F) {
@@ -155,7 +155,7 @@ getCloudConfig <- function(site_id,dir=NULL,uri=NULL,secret=NULL,silent_message=
   } else if (pda_uri!='') {
     config$uri = pda_uri
   } else{
-    mymessage('no cloud uri found! ')
+    # mymessage('no cloud uri found! ')
   }
   
   if(!is.null(dir)) {
@@ -193,7 +193,8 @@ pdaCatalog <- function(task=c('Regression',
                        write_json_file_path=getwd(), 
                        optim_maxit,
                        optim_method,
-                       init_method){
+                       init_method, 
+                       digits=digits){
   # a = Hmisc::list.tree(object, fill = " | ", attr.print = F, size = F, maxlen = 1)     
   # library(data.tree)
   # library(jsonlite)
@@ -338,7 +339,7 @@ pdaCatalog <- function(task=c('Regression',
   control$upload_date = Sys.time()
   
   write_json_file = menu(c("Yes", "No"), title="\nDo you want to write control into a json file at your specified folder? ")  
-  if(write_json_file==1) write(toJSON(control, digits = 4), file=paste0(write_json_file_path, '/control.json'))
+  if(write_json_file==1) write(toJSON(control, digits = digits), file=paste0(write_json_file_path, '/control.json'))
   
   return(control) 
 }

--- a/R/pda.R
+++ b/R/pda.R
@@ -39,12 +39,12 @@ pdaPut <- function(obj,name,config,upload_without_confirm=F,silent_message=F,dig
   obj_Json <- jsonlite::toJSON(obj, digits = digits)  # RJSONIO::toJSON(tt) keep vec name?
   file_name <- paste0(name, '.json')  
   
-  # if(!is.null(config$uri)){
-  #   mymessage(paste("Put",file_name,"on public cloud:"))
-  # }else{
-  #   mymessage(paste("Put",file_name,"on local directory", config$dir, ':'))
-  # }
-  # mymessage(obj_Json)
+  if(!is.null(config$uri)){
+    mymessage(paste("Put",file_name,"on public cloud:"))
+  }else{
+    mymessage(paste("Put",file_name,"on local directory", config$dir, ':'))
+  }
+  mymessage(obj_Json)
   
   # if(interactive()) {
   if(upload_without_confirm==F) {
@@ -155,7 +155,7 @@ getCloudConfig <- function(site_id,dir=NULL,uri=NULL,secret=NULL,silent_message=
   } else if (pda_uri!='') {
     config$uri = pda_uri
   } else{
-    # mymessage('no cloud uri found! ')
+    mymessage('no cloud uri found! ')
   }
   
   if(!is.null(dir)) {

--- a/R/pda.R
+++ b/R/pda.R
@@ -659,7 +659,7 @@ pda <- function(ipdata=NULL,site_id,control=NULL,dir=NULL,uri=NULL,secret=NULL,
     if (!is.null(ipdata)){ 
       # create stratum ID with strata_names (e.g. center, sex)
       # this part of code was taken out of prepare_case_cohort()
-      if (is.null(control$strata_names)) {
+      if (is.null(control$strata_names) | length(control$strata_names) == 0) {
         strata_id <- rep.int(1L, nrow(ipdata))
       } else {
         strata_vars <- ipdata[, control$strata_names, drop = F]

--- a/R/pda.R
+++ b/R/pda.R
@@ -686,10 +686,13 @@ pda <- function(ipdata=NULL,site_id,control=NULL,dir=NULL,uri=NULL,secret=NULL,
                                         strata_id = strata_id,
                                         # sampling_weight = ipdata$sampling_weight,
                                         model.matrix(formula, mf)[,-1])
-        precision <- min(diff(sort(ipdata$time_out))) / 2 # 
-        time_in = ifelse(ipdata$subcohort == 0, ipdata$time_out - precision, 0) 
-        ipdata = data.table(time_in=time_in, ipdata)
-      } 
+        ipdata$time_in <- 0
+      }
+      if(control$method == "Prentice"){
+        times <- sort(unique(c(ipdata$time_in, ipdata$time_out)))
+        precision <- min(diff(times)) / 2
+        ipdata[ipdata$subcohort == 0, "time_in"] <- ipdata[ipdata$subcohort == 0, "time_out"] - precision
+      }
       
       # convert irregular risk factor names, e.g. `Group (A,B,C) B` to Group..A.B.C..B
       # this should (and will) apply to all other models...


### PR DESCRIPTION
### Summary

This pull request introduces major internal updates to the **ODACH_CC (DRAFT)** pipeline, including full support for stratification. All changes are internal, preserve existing user-facing behaviour, and are released as a patch update (**v1.3.2**).

### Key changes

#### 1. Replacement of Rcpp derivative calculations

**Motivation:**
First and second derivatives are already computed internally by
`survival::coxph()`, making the existing Rcpp implementations redundant.
In addition to reduced computation time, `coxph()` provides robust internal
handling of numerical stability, risk sets, and event ties.

* Local-site derivative calculations now use `survival::coxph()` directly.
* The Rcpp-based implementations have not been removed 
   since they can be repurposed for other weighting methods.
* Consequently:

  * Explicit risk-set construction is no longer required (local site calculation only).
  * Filtering of degenerate variables is no longer necessary (handled by `survival`).

#### 2. Conditional application of Prentice weights

* In `R/pda.R`, Prentice weights are now applied **only when explicitly
  requested** via `control.json`,  avoiding unintended weighting when 
  alternative methods are selected.

#### 3. Complete stratification support

* Stratification has been added consistently to **all** `coxph` model formulas.

#### 4. Version update

* The patch version has been incremented to **1.3.2**, reflecting internal
  refactors and robustness improvements with no user-facing impact.

### Testing and robustness

* Fully tested on real data from the **EPIC–Somalogic** dataset.
* Robust to heterogeneous site conditions, including:

  * Missing variables
  * Missing cases
* No numerical instabilities or failures were observed.