### PR TITLE
bugfix: resolve ODACH_CC error when coxph is adjusted for a single co…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pda
 Type: Package
 Title: Privacy-Preserving Distributed Algorithms
-Version: 1.3.2
+Version: 1.3.3
 Date: 2026-02-05
 Authors@R: c(person("Chongliang", "Luo", role=c("cre"), email ="luocl3009@gmail.com"),
                 person("Rui", "Duan", role="aut"), person("Mackenzie", "Edmondson", role="aut"),
@@ -19,7 +19,7 @@ Authors@R: c(person("Chongliang", "Luo", role=c("cre"), email ="luocl3009@gmail.
 Description: A collection of privacy-preserving distributed algorithms (PDAs) for conducting federated statistical learning across multiple data sites. The PDA framework includes models for various tasks such as regression, trial emulation, causal inference, design-specific analysis, and clustering. The PDA algorithms run on a lead site and only require summary statistics from collaborating sites, with one or few iterations. The package can be used together with the online data transfer system (<https://pda-ota.pdamethods.org/>) for safe and convenient collaboration. For more information, please visit our software websites: <https://github.com/Penncil/pda>, and <https://pdamethods.org/>.
 Maintainer: Chongliang Luo <luocl3009@gmail.com>
 License: Apache License 2.0
-Suggests: lme4
+Suggests: lme4, testthat (>= 3.0.0)
 Depends: R (>= 4.1.0)
 Imports: Rcpp (>= 0.12.19), stats, httr, rvest, jsonlite, data.table,
         cobalt, EmpiricalCalibration, survival, minqa, glmnet, MASS,
@@ -27,6 +27,7 @@ Imports: Rcpp (>= 0.12.19), stats, httr, rvest, jsonlite, data.table,
         geex, data.tree
 LinkingTo: Rcpp, RcppArmadillo, RcppEigen
 RoxygenNote: 7.3.3
+Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 NeedsCompilation: yes

--- a/R/ODACH_CC.R
+++ b/R/ODACH_CC.R
@@ -114,7 +114,7 @@ ODACH_CC.initialize <- function(ipdata,control,config){
 #'   get_logL_D1(fit)
 #' }
 get_logL_D1 <- function(coxph_fit){
-  grad <- colSums(stats::residuals(coxph_fit, type = "score"))
+  grad <- colSums(as.matrix(stats::residuals(coxph_fit, type = "score")))
   logL_D1 <- as.vector(grad)
   return(logL_D1)
 }
@@ -148,7 +148,12 @@ get_logL_D1 <- function(coxph_fit){
 #' }
 get_logL_D2 <- function(coxph_fit){
   det <- survival::coxph.detail(coxph_fit, riskmat = FALSE)
-  I_total <- apply(det$imat, c(1, 2), sum)
+  imat <- det$imat
+  if (is.null(dim(imat))) {
+    I_total <- matrix(sum(imat), 1, 1)   # p == 1: imat is a length-d vector
+  } else {
+    I_total <- apply(imat, c(1, 2), sum) # p >= 2
+  }
   logL_D2 <- -as.matrix(I_total)
   dimnames(logL_D2) <- NULL
   return(logL_D2)
@@ -202,7 +207,7 @@ ODACH_CC.derive <- function(ipdata,control,config){
     method = "breslow",
     control = survival::coxph.control(iter.max = 0)
     )
-  
+
   logL_D1 <- get_logL_D1(fit_i)
   logL_D2 <- get_logL_D2(fit_i)
   

--- a/R/pda.R
+++ b/R/pda.R
@@ -678,14 +678,14 @@ pda <- function(ipdata=NULL,site_id,control=NULL,dir=NULL,uri=NULL,secret=NULL,
                                         subcohort = ipdata$subcohort,
                                         strata_id = strata_id,
                                         # sampling_weight = ipdata$sampling_weight,
-                                        model.matrix(formula, mf)[,-1])
+                                        model.matrix(formula, mf)[,-1, drop = FALSE])
       }else{ 
         ipdata = data.table::data.table(time_out=as.numeric(model.response(mf))[1:n], 
                                         status=as.numeric(model.response(mf))[(n+1):(2*n)], 
                                         subcohort = ipdata$subcohort,
                                         strata_id = strata_id,
                                         # sampling_weight = ipdata$sampling_weight,
-                                        model.matrix(formula, mf)[,-1])
+                                        model.matrix(formula, mf)[,-1, drop = FALSE])
         ipdata$time_in <- 0
       }
       if(isTRUE(control$method == "Prentice")){

--- a/R/pda.R
+++ b/R/pda.R
@@ -688,7 +688,7 @@ pda <- function(ipdata=NULL,site_id,control=NULL,dir=NULL,uri=NULL,secret=NULL,
                                         model.matrix(formula, mf)[,-1])
         ipdata$time_in <- 0
       }
-      if(control$method == "Prentice"){
+      if(isTRUE(control$method == "Prentice")){
         times <- sort(unique(c(ipdata$time_in, ipdata$time_out)))
         precision <- min(diff(times)) / 2
         ipdata[ipdata$subcohort == 0, "time_in"] <- ipdata[ipdata$subcohort == 0, "time_out"] - precision

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(pda)
+
+test_check("pda")

--- a/tests/testthat/test-ODACH_CC.R
+++ b/tests/testthat/test-ODACH_CC.R
@@ -1,0 +1,89 @@
+get_logL_D1 <- pda:::get_logL_D1
+get_logL_D2 <- pda:::get_logL_D2
+
+make_surv_data <- function(n = 200, seed = 1, p = 1) {
+  set.seed(seed)
+  df <- data.frame(
+    time = rexp(n, rate = 0.1),
+    status = rbinom(n, 1, 0.7)
+  )
+  for (i in seq_len(p)) {
+    df[[paste0("X", i)]] <- rnorm(n)
+  }
+  df
+}
+
+fit_coxph <- function(p, ...) {
+  df <- make_surv_data(p = p)
+  covars <- paste(paste0("X", seq_len(p)), collapse = "+")
+  form <- as.formula(paste("Surv(time, status) ~", covars))
+  survival::coxph(form, data = df, ...)
+}
+
+test_that("get_logL_D1 returns a vector of the right length for a single covariate", {
+  fit1 <- fit_coxph(p = 1)
+  d1 <- get_logL_D1(fit1)
+
+  expect_type(d1, "double")
+  expect_length(d1, 1)
+  # score residuals sum to ~0 at the MLE
+  expect_equal(d1, 0, tolerance = 1e-6)
+})
+
+test_that("get_logL_D1 returns a vector of the right length for multiple covariates", {
+  fit3 <- fit_coxph(p = 3)
+  d1 <- get_logL_D1(fit3)
+
+  expect_type(d1, "double")
+  expect_length(d1, 3)
+  expect_equal(d1, rep(0, 3), tolerance = 1e-6)
+})
+
+test_that("get_logL_D2 returns a 1x1 matrix for a single covariate and matches the model variance", {
+  fit1 <- fit_coxph(p = 1)
+  d2 <- get_logL_D2(fit1)
+
+  expect_true(is.matrix(d2))
+  expect_equal(dim(d2), c(1L, 1L))
+  # observed information is the inverse of the naive variance at the MLE
+  expect_equal(solve(-d2), fit1$var, tolerance = 1e-6)
+})
+
+test_that("get_logL_D2 returns a pxp matrix for multiple covariates and matches the model variance", {
+  fit3 <- fit_coxph(p = 3)
+  d2 <- get_logL_D2(fit3)
+
+  expect_true(is.matrix(d2))
+  expect_equal(dim(d2), c(3L, 3L))
+  expect_equal(solve(-d2), fit3$var, tolerance = 1e-6)
+})
+
+test_that("get_logL_D1/D2 work off the MLE (as used in ODACH_CC.derive/estimate) for p = 1", {
+  df <- make_surv_data(p = 1)
+  fit0 <- survival::coxph(
+    Surv(time, status) ~ X1, data = df,
+    init = 0, method = "breslow",
+    control = survival::coxph.control(iter.max = 0)
+  )
+
+  d1 <- expect_no_error(get_logL_D1(fit0))
+  d2 <- expect_no_error(get_logL_D2(fit0))
+
+  expect_length(d1, 1)
+  expect_equal(dim(d2), c(1L, 1L))
+})
+
+test_that("get_logL_D1/D2 work off the MLE for multiple covariates", {
+  df <- make_surv_data(p = 3)
+  fit0 <- survival::coxph(
+    Surv(time, status) ~ X1 + X2 + X3, data = df,
+    init = c(0, 0, 0), method = "breslow",
+    control = survival::coxph.control(iter.max = 0)
+  )
+
+  d1 <- expect_no_error(get_logL_D1(fit0))
+  d2 <- expect_no_error(get_logL_D2(fit0))
+
+  expect_length(d1, 3)
+  expect_equal(dim(d2), c(3L, 3L))
+})


### PR DESCRIPTION
## bugfix: resolve ODACH_CC error when coxph is adjusted for a single covariate

**Version:** 1.3.2 → 1.3.3

### Changes
- `R/ODACH_CC.R` — `get_logL_D1`/`get_logL_D2` failed when a `coxph` fit had only one covariate (score residuals/`imat` drop to vectors instead of matrices, breaking `colSums`/`apply`). Both now handle the p=1 case explicitly.
- `R/pda.R:691` — guarded `control$method == "Prentice"` with `isTRUE()` so a `NULL` method doesn't throw (`if(logical(0))` error), matching the existing pattern used for `control$mixed_effects`.
- `tests/testthat/` — new suite (`test-ODACH_CC.R`) covering `get_logL_D1`/`get_logL_D2` for p=1 and p≥2, both at and off the MLE; verified it fails against the pre-fix code and passes against the fix.
- `DESCRIPTION` — added `testthat (>= 3.0.0)` to `Suggests` and `Config/testthat/edition: 3`.